### PR TITLE
Upgrade ms to ^2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "ms": "^2.0.0"
+    "ms": "^2.1.1"
   },
   "devDependencies": {
     "autod": "*",


### PR DESCRIPTION
This project depends on `ms@^2.0.0`, somehow `npm install` (seen with npm `5.7.x` and `5.8.x`) keeps installing `ms@2.0.0` on clean installs, disregarding more recent `ms` versions that would still satisfy the caret semver notation. I could not find out why.

This PR upgrades `ms` to its latest version. The main reason for this is the addition of the `week` unit in `ms`.

Here is `npm ls` with and without:

```diff
 $ npm ls ms
 ├─┬ body-parser@1.18.2
 │ └─┬ debug@2.6.9
 │   └── ms@2.0.0  deduped
 ├─┬ eslint@4.19.1
 │ └─┬ debug@3.1.0
 │   └── ms@2.0.0  deduped
 ├─┬ express@4.16.3
 │ └─┬ send@0.16.2
 │   └── ms@2.0.0  deduped
 ├─┬ gm@1.23.1
 │ └─┬ debug@3.1.0
 │   └── ms@2.0.0  deduped
-├─┬ humanize-ms@1.2.1
-│ └── ms@2.0.0
+├─┬ humanize-ms@1.2.1 (git+https://git@github.com/vhf/humanize-ms.git#5714d1d7344e3acf16c5b91e732459d3402c4c0e)
+│ └── ms@2.1.1
 ├─┬ jsonwebtoken@8.2.0
 │ └── ms@2.1.1
 ├─┬ knex@0.14.4
 │ └─┬ debug@3.1.0
 │   └── ms@2.0.0  deduped
 ├─┬ mocha@5.0.5
 │ └─┬ debug@3.1.0
 │   └── ms@2.0.0  deduped
 └─┬ nock@9.2.3
   └─┬ debug@3.1.0
     └── ms@2.0.0  deduped
```